### PR TITLE
Bump API to 3.0.0-ALPHA10

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -3,7 +3,7 @@ author: jojoe77777
 version: 1.3.7
 description: Slapper, the NPC plugin for PocketMine-MP
 main: slapper\Main
-api: [3.0.0-ALPHA9]
+api: [3.0.0-ALPHA9, 3.0.0-ALPHA10]
 website: https://github.com/jojoe77777/Slapper
 
 commands:


### PR DESCRIPTION
API changes did not affect Slapper.  API bump will maintain existing operation.