### PR TITLE
Fix Custom Geometry issue #102 on SlapperHuman skins.

### DIFF
--- a/src/slapper/Main.php
+++ b/src/slapper/Main.php
@@ -11,6 +11,7 @@ use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\event\entity\EntitySpawnEvent;
 use pocketmine\event\Listener;
 use pocketmine\Item\Item;
+use pocketmine\nbt\tag\ByteArrayTag;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\DoubleTag;
 use pocketmine\nbt\tag\FloatTag;
@@ -676,11 +677,11 @@ class Main extends PluginBase implements Listener {
 			$player->saveNBT();
 			$nbt->Inventory = clone $player->namedtag->Inventory;
 			$nbt->Skin = new CompoundTag("Skin", [
-				"Data" => new StringTag("Data", $player->getSkin()->getSkinData()),
-				"Name" => new StringTag("Name", $player->getSkin()->getSkinId()),
-				"Cape" => new StringTag("Cape", $player->getSkin()->getCapeData()),
-				"GeometryName" => new StringTag("GeometryName", $player->getSkin()->getGeometryName()),
-				"GeometryData" => new StringTag("GeometryData", $player->getSkin()->getGeometryData())
+				new StringTag("Data", $player->getSkin()->getSkinData()),
+				new StringTag("Name", $player->getSkin()->getSkinId()),
+				new StringTag("Cape", $player->getSkin()->getCapeData()),
+				new StringTag("GeometryName", $player->getSkin()->getGeometryName()),
+				new ByteArrayTag("GeometryData", $player->getSkin()->getGeometryData())
 			]);
 		}
 		return $nbt;

--- a/src/slapper/Main.php
+++ b/src/slapper/Main.php
@@ -670,10 +670,18 @@ class Main extends PluginBase implements Listener {
 		$nbt->Commands = new CompoundTag("Commands", []);
 		$nbt->MenuName = new StringTag("MenuName", "");
 		$nbt->SlapperVersion = new StringTag("SlapperVersion", $this->getDescription()->getVersion());
-		if($type === "Human") {
+
+		// TODO: This will need to be updated when PMMP updates Human class to handle Capes and Custom Geometry
+		if($type === "Human"){
 			$player->saveNBT();
 			$nbt->Inventory = clone $player->namedtag->Inventory;
-			$nbt->Skin = new CompoundTag("Skin", ["Data" => new StringTag("Data", $player->getSkin()->getSkinData()), "Name" => new StringTag("Name", $player->getSkin()->getSkinId())]);
+			$nbt->Skin = new CompoundTag("Skin", [
+				"Data" => new StringTag("Data", $player->getSkin()->getSkinData()),
+				"Name" => new StringTag("Name", $player->getSkin()->getSkinId()),
+				"Cape" => new StringTag("Cape", $player->getSkin()->getCapeData()),
+				"GeometryName" => new StringTag("GeometryName", $player->getSkin()->getGeometryName()),
+				"GeometryData" => new StringTag("GeometryData", $player->getSkin()->getGeometryData())
+			]);
 		}
 		return $nbt;
 	}

--- a/src/slapper/Main.php
+++ b/src/slapper/Main.php
@@ -653,36 +653,36 @@ class Main extends PluginBase implements Listener {
 	 */
 	private function makeNBT($type, Player $player) {
 		$nbt = new CompoundTag;
-		$nbt->Pos = new ListTag("Pos", [
+		$nbt->setTag(new ListTag("Pos", [
 			new DoubleTag("", $player->getX()),
 			new DoubleTag("", $player->getY()),
 			new DoubleTag("", $player->getZ())
-		]);
-		$nbt->Motion = new ListTag("Motion", [
+		]));
+		$nbt->setTag(new ListTag("Motion", [
 			new DoubleTag("", 0),
 			new DoubleTag("", 0),
 			new DoubleTag("", 0)
-		]);
-		$nbt->Rotation = new ListTag("Rotation", [
+		]));
+		$nbt->setTag(new ListTag("Rotation", [
 			new FloatTag("", $player->getYaw()),
 			new FloatTag("", $player->getPitch())
-		]);
-		$nbt->Health = new ShortTag("Health", 1);
-		$nbt->Commands = new CompoundTag("Commands", []);
-		$nbt->MenuName = new StringTag("MenuName", "");
-		$nbt->SlapperVersion = new StringTag("SlapperVersion", $this->getDescription()->getVersion());
+		]));
+		$nbt->setTag(new ShortTag("Health", 1));
+		$nbt->setTag(new CompoundTag("Commands", []));
+		$nbt->setTag(new StringTag("MenuName", ""));
+		$nbt->setTag(new StringTag("SlapperVersion", $this->getDescription()->getVersion()));
 
 		// TODO: This will need to be updated when PMMP updates Human class to handle Capes and Custom Geometry
 		if($type === "Human"){
 			$player->saveNBT();
-			$nbt->Inventory = clone $player->namedtag->Inventory;
-			$nbt->Skin = new CompoundTag("Skin", [
+			$nbt->setTag(clone $player->namedtag->Inventory);
+			$nbt->setTag(new CompoundTag("Skin", [
 				new StringTag("Data", $player->getSkin()->getSkinData()),
 				new StringTag("Name", $player->getSkin()->getSkinId()),
 				new StringTag("Cape", $player->getSkin()->getCapeData()),
 				new StringTag("GeometryName", $player->getSkin()->getGeometryName()),
 				new ByteArrayTag("GeometryData", $player->getSkin()->getGeometryData())
-			]);
+			]));
 		}
 		return $nbt;
 	}

--- a/src/slapper/entities/SlapperEntity.php
+++ b/src/slapper/entities/SlapperEntity.php
@@ -43,7 +43,7 @@ class SlapperEntity extends Entity {
 		}
 		$this->setDataFlag(self::DATA_FLAGS, self::DATA_FLAG_IMMOBILE, true);
 		if(!isset($this->namedtag->Scale)) {
-			$this->namedtag->Scale = new FloatTag("Scale", 1.0);
+			$this->namedtag->setTag(new FloatTag("Scale", 1.0));
 		}
 		$this->setDataProperty(self::DATA_SCALE, self::DATA_TYPE_FLOAT, $this->namedtag->Scale->getValue());
 		$this->setDataProperty(self::DATA_BOUNDING_BOX_HEIGHT, self::DATA_TYPE_FLOAT, static::HEIGHT);
@@ -59,8 +59,8 @@ class SlapperEntity extends Entity {
 			}
 		}
 		$scale = $this->getDataProperty(Entity::DATA_SCALE);
-		$this->namedtag->NameVisibility = new IntTag("NameVisibility", $visibility);
-		$this->namedtag->Scale = new FloatTag("Scale", $scale);
+		$this->namedtag->setTag(new IntTag("NameVisibility", $visibility));
+		$this->namedtag->setTag(new FloatTag("Scale", $scale));
 	}
 
 	protected function sendSpawnPacket(Player $player) : void{

--- a/src/slapper/entities/SlapperHuman.php
+++ b/src/slapper/entities/SlapperHuman.php
@@ -17,7 +17,7 @@ class SlapperHuman extends Human {
 	public function __construct(Level $level, CompoundTag $nbt) {
 		parent::__construct($level, $nbt);
 		if(!isset($this->namedtag->NameVisibility)) {
-			$this->namedtag->NameVisibility = new IntTag("NameVisibility", 2);
+			$this->namedtag->setTag(new IntTag("NameVisibility", 2));
 		}
 		switch ($this->namedtag->NameVisibility->getValue()) {
 			case 0:
@@ -38,7 +38,7 @@ class SlapperHuman extends Human {
 				break;
 		}
 		if(!isset($this->namedtag->Scale)) {
-			$this->namedtag->Scale = new FloatTag("Scale", 1.0);
+			$this->namedtag->setTag(new FloatTag("Scale", 1.0));
 		}
 		$this->setDataProperty(self::DATA_SCALE, self::DATA_TYPE_FLOAT, $this->namedtag->Scale->getValue());
 	}
@@ -68,8 +68,8 @@ class SlapperHuman extends Human {
 			}
 		}
 		$scale = $this->getDataProperty(Entity::DATA_SCALE);
-		$this->namedtag->NameVisibility = new IntTag("NameVisibility", $visibility);
-		$this->namedtag->Scale = new FloatTag("Scale", $scale);
+		$this->namedtag->setTag(new IntTag("NameVisibility", $visibility));
+		$this->namedtag->setTag(new FloatTag("Scale", $scale));
 		if($this->skin !== null){
 			// TODO: This will need to be updated when PMMP updates Human class to handle Capes and Custom Geometry
 			$this->namedtag->setTag(new CompoundTag("Skin", [

--- a/src/slapper/entities/SlapperHuman.php
+++ b/src/slapper/entities/SlapperHuman.php
@@ -5,6 +5,7 @@ use pocketmine\entity\Entity;
 use pocketmine\entity\Human;
 use pocketmine\entity\Skin;
 use pocketmine\level\Level;
+use pocketmine\nbt\tag\ByteArrayTag;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\FloatTag;
 use pocketmine\nbt\tag\IntTag;
@@ -52,7 +53,7 @@ class SlapperHuman extends Human {
 			$data = $skin->getString("Data");
 			$cape = isset($skin["Cape"]) ? $skin->getString("Cape") : "";
 			$geometryName = isset($skin["GeometryName"]) ? $skin->getString("GeometryName") : "";
-			$geometryData = isset($skin["GeometryData"]) ? $skin->getString("GeometryData") : "";
+			$geometryData = isset($skin["GeometryData"]) ? $skin->getByteArray("GeometryData") : "";
 			$this->setSkin(new Skin($name, $data, $cape, $geometryName, $geometryData));
 		}
 	}
@@ -76,7 +77,7 @@ class SlapperHuman extends Human {
 				new StringTag("Name", $this->skin->getSkinId()),
 				new StringTag("Cape", $this->skin->getCapeData()),
 				new StringTag("GeometryName", $this->skin->getGeometryName()),
-				new StringTag("GeometryData", $this->skin->getGeometryData())
+				new ByteArrayTag("GeometryData", $this->skin->getGeometryData())
 			]) );
 		}
 	}

--- a/src/slapper/entities/SlapperHuman.php
+++ b/src/slapper/entities/SlapperHuman.php
@@ -3,10 +3,12 @@ namespace slapper\entities;
 
 use pocketmine\entity\Entity;
 use pocketmine\entity\Human;
+use pocketmine\entity\Skin;
 use pocketmine\level\Level;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\FloatTag;
 use pocketmine\nbt\tag\IntTag;
+use pocketmine\nbt\tag\StringTag;
 use pocketmine\Player;
 
 class SlapperHuman extends Human {
@@ -40,6 +42,21 @@ class SlapperHuman extends Human {
 		$this->setDataProperty(self::DATA_SCALE, self::DATA_TYPE_FLOAT, $this->namedtag->Scale->getValue());
 	}
 
+	// TODO: This can be removed when PMMP updates Human class to handle Capes and Custom Geometry
+	protected function initHumanData(){
+		parent::initHumanData();
+
+		$skin = $this->namedtag->getCompoundTag("Skin");
+		if($skin !== null){
+			$name = $skin->getString("Name");
+			$data = $skin->getString("Data");
+			$cape = isset($skin["Cape"]) ? $skin->getString("Cape") : "";
+			$geometryName = isset($skin["GeometryName"]) ? $skin->getString("GeometryName") : "";
+			$geometryData = isset($skin["GeometryData"]) ? $skin->getString("GeometryData") : "";
+			$this->setSkin(new Skin($name,$data, $cape, $geometryName, $geometryData));
+		}
+	}
+
 	public function saveNBT() {
 		parent::saveNBT();
 		$visibility = 0;
@@ -52,6 +69,16 @@ class SlapperHuman extends Human {
 		$scale = $this->getDataProperty(Entity::DATA_SCALE);
 		$this->namedtag->NameVisibility = new IntTag("NameVisibility", $visibility);
 		$this->namedtag->Scale = new FloatTag("Scale", $scale);
+		if($this->skin !== null){
+			// TODO: This will need to be updated when PMMP updates Human class to handle Capes and Custom Geometry
+			$this->namedtag->setTag(new CompoundTag("Skin", [
+				new StringTag("Data", $this->skin->getSkinData()),
+				new StringTag("Name", $this->skin->getSkinId()),
+				new StringTag("Cape", $this->skin->getCapeData()),
+				new StringTag("GeometryName", $this->skin->getGeometryName()),
+				new StringTag("GeometryData", $this->skin->getGeometryData())
+			]) );
+		}
 	}
 
 	protected function sendSpawnPacket(Player $player) : void{

--- a/src/slapper/entities/SlapperHuman.php
+++ b/src/slapper/entities/SlapperHuman.php
@@ -53,7 +53,7 @@ class SlapperHuman extends Human {
 			$cape = isset($skin["Cape"]) ? $skin->getString("Cape") : "";
 			$geometryName = isset($skin["GeometryName"]) ? $skin->getString("GeometryName") : "";
 			$geometryData = isset($skin["GeometryData"]) ? $skin->getString("GeometryData") : "";
-			$this->setSkin(new Skin($name,$data, $cape, $geometryName, $geometryData));
+			$this->setSkin(new Skin($name, $data, $cape, $geometryName, $geometryData));
 		}
 	}
 


### PR DESCRIPTION
This will make it possible to use skins with capes, and other custom geometry, on human slappers.  During testing, this did not affect existing Slappers meaning that Slappers created before using this update would still work as before.  Any Slapper that was previously set to use a skin with a cape or custom geometry will need to have their skin updated once this update is installed.  Skin changes will persist through server restarts under normal circumstances.