### PR TITLE
Added SlapperTrait, cut down on duplicated code

### DIFF
--- a/src/slapper/SlapperTrait.php
+++ b/src/slapper/SlapperTrait.php
@@ -1,24 +1,5 @@
 <?php
 
-/*
- *
- *  ____            _        _   __  __ _                  __  __ ____
- * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
- * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
- * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
- * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * @author PocketMine Team
- * @link http://www.pocketmine.net/
- *
- *
-*/
-
 declare(strict_types=1);
 
 namespace slapper;

--- a/src/slapper/SlapperTrait.php
+++ b/src/slapper/SlapperTrait.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace slapper;
+
+use pocketmine\entity\DataPropertyManager;
+use pocketmine\entity\Entity;
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\FloatTag;
+use pocketmine\nbt\tag\IntTag;
+use pocketmine\Player;
+
+/**
+ * Trait containing methods used in various Slappers.
+ */
+trait SlapperTrait{
+	/** @var CompoundTag */
+	public $namedtag;
+
+	/**
+	 * @return DataPropertyManager
+	 */
+	abstract public function getDataPropertyManager() : DataPropertyManager;
+
+	/**
+	 * @return string
+	 */
+	abstract public function getNameTag();
+
+	abstract public function isNameTagVisible() : bool;
+
+	abstract public function isNameTagAlwaysVisible() : bool;
+
+	abstract public function setNameTagVisible(bool $value);
+
+	abstract public function setNameTagAlwaysVisible(bool $value);
+
+	abstract public function setGenericFlag(int $flag, bool $value = true);
+
+	public function prepareMetadata() : void{
+		if(!$this->namedtag->hasTag("NameVisibility", IntTag::class)) {
+			$this->namedtag->setInt("NameVisibility", 2, true);
+		}
+		switch ($this->namedtag->getInt("NameVisibility")) {
+			case 0:
+				$this->setNameTagVisible(false);
+				$this->setNameTagAlwaysVisible(false);
+				break;
+			case 1:
+				$this->setNameTagVisible(true);
+				$this->setNameTagAlwaysVisible(false);
+				break;
+			case 2:
+				$this->setNameTagVisible(true);
+				$this->setNameTagAlwaysVisible(true);
+				break;
+			default:
+				$this->setNameTagVisible(true);
+				$this->setNameTagAlwaysVisible(true);
+				break;
+		}
+		$this->setGenericFlag(Entity::DATA_FLAG_IMMOBILE, true);
+		if(!$this->namedtag->hasTag("Scale", FloatTag::class)) {
+			$this->namedtag->setFloat("Scale", 1.0, true);
+		}
+		$this->getDataPropertyManager()->setFloat(Entity::DATA_SCALE, $this->namedtag->getFloat("Scale"));
+	}
+
+	public function saveSlapperNbt() : void{
+		$visibility = 0;
+		if($this->isNameTagVisible()) {
+			$visibility = 1;
+			if($this->isNameTagAlwaysVisible()) {
+				$visibility = 2;
+			}
+		}
+		$scale = $this->getDataPropertyManager()->getFloat(Entity::DATA_SCALE);
+		$this->namedtag->setInt("NameVisibility", $visibility, true);
+		$this->namedtag->setFloat("Scale", $scale, true);
+	}
+
+	public function getDisplayName(Player $player) : string{
+		$vars = [
+			"{name}" => $player->getName(),
+			"{display_name}" => $player->getName(),
+			"{nametag}" => $player->getNameTag()
+		];
+		return str_replace(array_keys($vars), array_values($vars), $this->getNameTag());
+	}
+}

--- a/src/slapper/entities/SlapperElderGuardian.php
+++ b/src/slapper/entities/SlapperElderGuardian.php
@@ -6,7 +6,7 @@ class SlapperElderGuardian extends SlapperEntity {
 	const TYPE_ID = 50;
 	const HEIGHT = 1.9975;
 
-	public function prepareMetadata() {
+	public function prepareMetadata() : void{
 		$this->setDataFlag(self::DATA_FLAGS, self::DATA_FLAG_ELDER, true);
 		parent::prepareMetadata();
 	}

--- a/src/slapper/entities/SlapperEntity.php
+++ b/src/slapper/entities/SlapperEntity.php
@@ -8,8 +8,10 @@ use pocketmine\nbt\tag\FloatTag;
 use pocketmine\nbt\tag\IntTag;
 use pocketmine\network\mcpe\protocol\AddEntityPacket;
 use pocketmine\Player;
+use slapper\SlapperTrait;
 
 class SlapperEntity extends Entity {
+	use SlapperTrait;
 
 	const TYPE_ID = 0;
 	const HEIGHT = 0;
@@ -21,48 +23,9 @@ class SlapperEntity extends Entity {
 		$this->prepareMetadata();
 	}
 
-	public function prepareMetadata() {
-		if(!$this->namedtag->hasTag("NameVisibility", IntTag::class)) {
-			$this->namedtag->setInt("NameVisibility", 2, true);
-		}
-		switch ($this->namedtag->getInt("NameVisibility")) {
-			case 0:
-				$this->setNameTagVisible(false);
-				$this->setNameTagAlwaysVisible(false);
-				break;
-			case 1:
-				$this->setNameTagVisible(true);
-				$this->setNameTagAlwaysVisible(false);
-				break;
-			case 2:
-				$this->setNameTagVisible(true);
-				$this->setNameTagAlwaysVisible(true);
-				break;
-			default:
-				$this->setNameTagVisible(true);
-				$this->setNameTagAlwaysVisible(true);
-				break;
-		}
-		$this->setDataFlag(self::DATA_FLAGS, self::DATA_FLAG_IMMOBILE, true);
-		if(!$this->namedtag->hasTag("Scale", FloatTag::class)) {
-			$this->namedtag->setFloat("Scale", 1.0, true);
-		}
-		$this->getDataPropertyManager()->setFloat(self::DATA_SCALE, $this->namedtag->getFloat("Scale"));
-		$this->getDataPropertyManager()->setFloat(self::DATA_BOUNDING_BOX_HEIGHT, static::HEIGHT);
-	}
-
 	public function saveNBT() {
 		parent::saveNBT();
-		$visibility = 0;
-		if($this->isNameTagVisible()) {
-			$visibility = 1;
-			if($this->isNameTagAlwaysVisible()) {
-				$visibility = 2;
-			}
-		}
-		$scale = $this->getDataPropertyManager()->getFloat(Entity::DATA_SCALE);
-		$this->namedtag->setInt("NameVisibility", $visibility, true);
-		$this->namedtag->setFloat("Scale", $scale, true);
+		$this->saveSlapperNbt();
 	}
 
 	protected function sendSpawnPacket(Player $player) : void{
@@ -77,14 +40,4 @@ class SlapperEntity extends Entity {
 
 		$player->dataPacket($pk);
 	}
-
-	public function getDisplayName(Player $player) {
-		$vars = [
-			"{name}" => $player->getName(),
-			"{display_name}" => $player->getName(),
-			"{nametag}" => $player->getNameTag()
-		];
-		return str_replace(array_keys($vars), array_values($vars), $this->getNameTag());
-	}
-
 }

--- a/src/slapper/entities/SlapperEntity.php
+++ b/src/slapper/entities/SlapperEntity.php
@@ -23,36 +23,6 @@ class SlapperEntity extends Entity {
 		$this->prepareMetadata();
 	}
 
-	public function prepareMetadata() {
-		if(!$this->namedtag->hasTag("NameVisibility", IntTag::class)) {
-			$this->namedtag->setInt("NameVisibility", 2, true);
-		}
-		switch ($this->namedtag->getInt("NameVisibility")) {
-			case 0:
-				$this->setNameTagVisible(false);
-				$this->setNameTagAlwaysVisible(false);
-				break;
-			case 1:
-				$this->setNameTagVisible(true);
-				$this->setNameTagAlwaysVisible(false);
-				break;
-			case 2:
-				$this->setNameTagVisible(true);
-				$this->setNameTagAlwaysVisible(true);
-				break;
-			default:
-				$this->setNameTagVisible(true);
-				$this->setNameTagAlwaysVisible(true);
-				break;
-		}
-		$this->setDataFlag(self::DATA_FLAGS, self::DATA_FLAG_IMMOBILE, true);
-		if(!$this->namedtag->hasTag("Scale", FloatTag::class)) {
-			$this->namedtag->setFloat("Scale", 1.0, true);
-		}
-		$this->getDataPropertyManager()->setFloat(self::DATA_SCALE, $this->namedtag->getFloat("Scale"));
-		$this->getDataPropertyManager()->setFloat(self::DATA_BOUNDING_BOX_HEIGHT, static::HEIGHT);
-	}
-
 	public function saveNBT() : void{
 		parent::saveNBT();
 		$this->saveSlapperNbt();

--- a/src/slapper/entities/SlapperHuman.php
+++ b/src/slapper/entities/SlapperHuman.php
@@ -8,51 +8,19 @@ use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\FloatTag;
 use pocketmine\nbt\tag\IntTag;
 use pocketmine\Player;
+use slapper\SlapperTrait;
 
 class SlapperHuman extends Human {
+	use SlapperTrait;
 
 	public function __construct(Level $level, CompoundTag $nbt) {
 		parent::__construct($level, $nbt);
-		if(!$this->namedtag->hasTag("NameVisibility", IntTag::class)) {
-			$this->namedtag->setInt("NameVisibility", 2, true);
-		}
-		switch ($this->namedtag->getInt("NameVisibility")) {
-			case 0:
-				$this->setNameTagVisible(false);
-				$this->setNameTagAlwaysVisible(false);
-				break;
-			case 1:
-				$this->setNameTagVisible(true);
-				$this->setNameTagAlwaysVisible(false);
-				break;
-			case 2:
-				$this->setNameTagVisible(true);
-				$this->setNameTagAlwaysVisible(true);
-				break;
-			default:
-				$this->setNameTagVisible(true);
-				$this->setNameTagAlwaysVisible(true);
-				break;
-		}
-		$this->setDataFlag(self::DATA_FLAGS, self::DATA_FLAG_IMMOBILE, true);
-		if(!$this->namedtag->hasTag("Scale", FloatTag::class)) {
-			$this->namedtag->setFloat("Scale", 1.0, true);
-		}
-		$this->getDataPropertyManager()->setFloat(self::DATA_SCALE, $this->namedtag->getFloat("Scale"));
+		$this->prepareMetadata();
 	}
 
 	public function saveNBT() {
 		parent::saveNBT();
-		$visibility = 0;
-		if($this->isNameTagVisible()) {
-			$visibility = 1;
-			if($this->isNameTagAlwaysVisible()) {
-				$visibility = 2;
-			}
-		}
-		$scale = $this->getDataPropertyManager()->getFloat(Entity::DATA_SCALE);
-		$this->namedtag->setInt("NameVisibility", $visibility, true);
-		$this->namedtag->setFloat("Scale", $scale, true);
+		$this->saveSlapperNbt();
 	}
 
 	protected function sendSpawnPacket(Player $player) : void{
@@ -63,16 +31,5 @@ class SlapperHuman extends Human {
 		if(($menuName = $this->namedtag->getString("MenuName", "", true)) !== "") {
 			$player->getServer()->updatePlayerListData($this->getUniqueId(), $this->getId(), $menuName, $this->skin, "", [$player]);
 		}
-
 	}
-
-	public function getDisplayName(Player $player) {
-		$vars = [
-			"{name}" => $player->getName(),
-			"{display_name}" => $player->getName(),
-			"{nametag}" => $player->getNameTag()
-		];
-		return str_replace(array_keys($vars), array_values($vars), $this->getNameTag());
-	}
-
 }


### PR DESCRIPTION
This hasn't been thoroughly tested. Utilize traits to reduce code duplication between different Slapper class extensions.

It may also be desirable to pair this with a `Slapper` interface.